### PR TITLE
Change html element functions to use argument splatting

### DIFF
--- a/src/Kelpie.jl
+++ b/src/Kelpie.jl
@@ -61,10 +61,10 @@ const HTML_ELEMENTS = [
 ]
 
 """
-    link_or_text!(node, content)
+    link_or_text!(node, content...)
 
-Converts `content` to an `EzXML.TextNode` if it isn't already an `EzXML.Node` and links it
-to `node`. Will link all nodes in `content` if content is a vector.
+Converts each `content` to an `EzXML.TextNode` if it isn't already an `EzXML.Node` and links
+it to `node`.
 
 ```jldoctest
 julia> import EzXML: ElementNode, prettyprint; import Kelpie: link_or_text!
@@ -77,30 +77,24 @@ julia> prettyprint(link_or_text!(ElementNode("div"), ElementNode("br")))
 julia> prettyprint(link_or_text!(ElementNode("h1"), "Kelpie.jl"))
 <h1>Kelpie.jl</h1>
 
-julia> prettyprint(link_or_text!(ElementNode("div"), ["The end", ElementNode("hr")]))
+julia> prettyprint(link_or_text!(ElementNode("div"), "The end", ElementNode("hr")))
 <div>The end<hr/></div>
 ```
 """
-function link_or_text!(node, content)
-    if typeof(content) <: EzXML.Node
-        link!(node, content)
-    else
-        link!(node, EzXML.TextNode(string(content)))
-    end #if
-
-    return node
-end #function
-
-function link_or_text!(node, content::AbstractArray)
+function link_or_text!(node, content...)
     for con in content
-        link_or_text!(node, con)
+        if typeof(con) <: EzXML.Node
+            link!(node, con)
+        else
+            link!(node, EzXML.TextNode(string(con)))
+        end #if
     end #for
 
     return node
 end #function
 
 """
-    html_element(name, content=nothing; kwargs...)
+    html_element(name, content...=nothing; kwargs...)
 
 Creates a new `EzXML.Node` with name `name`, containing `content`, and with attributes
 specified by `kwargs`.
@@ -117,7 +111,7 @@ julia> prettyprint(html_element("span", "MillironX"; class="label-primary"))
 <span class="label-primary">MillironX</span>
 ```
 """
-function html_element(name::AbstractString, content=nothing; kwargs...)
+function html_element(name::AbstractString, content...=nothing; kwargs...)
     el = EzXML.ElementNode(name)
 
     for (key, value) in kwargs
@@ -125,34 +119,34 @@ function html_element(name::AbstractString, content=nothing; kwargs...)
     end #for
 
     if !isnothing(content)
-        link_or_text!(el, content)
+        link_or_text!(el, content...)
     end #if
 
     return el
 end #function
 
 """
-    html(content)
+    html(content...)
 
 Creates a new HTML document filled with `content`.
 """
-function html(content)
+function html(content...)
     doc = EzXML.HTMLDocumentNode(nothing, nothing)
-    link_or_text!(doc, content)
+    link_or_text!(doc, content...)
     return doc
 end #function
 
 for symbol in HTML_ELEMENTS
     name = string(symbol)
 
-    @eval function $symbol(content=nothing; kwargs...)
-        return html_element($name, content; kwargs...)
+    @eval function $symbol(content...=nothing; kwargs...)
+        return html_element($name, content...; kwargs...)
     end #function
 
     @eval export $symbol
 end
 
-function html_div(content=nothing; kwargs...)
+function html_div(content...=nothing; kwargs...)
     return html_element("div", content; kwargs...)
 end #function
 


### PR DESCRIPTION
I had a weird check for an array in the linking functions, but Julia supports argument splatting, so we can just chain an arbitrary number of arguments without checking for arrays. Will break things because arrays will be processed as a single element now.