### PR TITLE
Fix for `html` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Arrays of content replaced with argument splatting ([#2](https://github.com/MillironX/Kelpie.jl/pull/2))
 
+### Fixed
+
+- `html()` now returns an `<html>` node, not just a document ([#3](https://github.com/MillironX/Kelpie.jl/pull/3))
+
 ## [0.1.0] - 2022-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,22 +60,24 @@ Turns into
 
 ```html
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
-<head>
-  <title>Kelpie.jl is awesome!</title>
-</head>
-<body>
-  <header>
-    <h1>Dogs are cool</h1>
-    <h2>Julia is cool</h2>
-  </header>
-  <main>
-    <img src="/kelpie-on-sheep-back.jpg" alt="A Kelpie herding sheep" />
-    <p>Kelpies make great herding dogs for cows.</p>
-    <p>Kelpies make great herding dogs for sheep.</p>
-    <p>Kelpies make great herding dogs for chickens.</p>
-  </main>
-</body>
+<!DOCTYPE html SYSTEM "about:legacy-compat">
+<html>
+  <head>
+    <title>Kelpie.jl is awesome!</title>
+  </head>
+  <body>
+    <header>
+      <h1>Dogs are cool</h1>
+      <h2>Julia is cool</h2>
+    </header>
+    <main>
+      <img src="/kelpie-on-sheep-back.jpg" alt="A Kelpie herding sheep" />
+      <p>Kelpies make great herding dogs for cows.</p>
+      <p>Kelpies make great herding dogs for sheep.</p>
+      <p>Kelpies make great herding dogs for chickens.</p>
+    </main>
+  </body>
+</html>
 ```
 
 Everything is pure Julia, so your imagination is the limit!

--- a/src/Kelpie.jl
+++ b/src/Kelpie.jl
@@ -131,6 +131,17 @@ end #function
     html(content...=nothing; kwargs...)
 
 Creates a new HTML document filled with `content`.
+
+# Example
+
+```jldoctest
+julia> import EzXML: prettyprint
+
+julia> prettyprint(html())
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE html SYSTEM "about:legacy-compat">
+<html/>
+```
 """
 function html(content...=nothing; kwargs...)
     doc = EzXML.HTMLDocumentNode("about:legacy-compat", nothing)

--- a/src/Kelpie.jl
+++ b/src/Kelpie.jl
@@ -131,7 +131,7 @@ end #function
 Creates a new HTML document filled with `content`.
 """
 function html(content...)
-    doc = EzXML.HTMLDocumentNode(nothing, nothing)
+    doc = EzXML.HTMLDocumentNode("about:legacy-compat", nothing)
     link_or_text!(doc, content...)
     return doc
 end #function

--- a/src/Kelpie.jl
+++ b/src/Kelpie.jl
@@ -83,10 +83,12 @@ julia> prettyprint(link_or_text!(ElementNode("div"), "The end", ElementNode("hr"
 """
 function link_or_text!(node, content...)
     for con in content
-        if typeof(con) <: EzXML.Node
-            link!(node, con)
-        else
-            link!(node, EzXML.TextNode(string(con)))
+        if !isnothing(con)
+            if typeof(con) <: EzXML.Node
+                link!(node, con)
+            else
+                link!(node, EzXML.TextNode(string(con)))
+            end #if
         end #if
     end #for
 

--- a/src/Kelpie.jl
+++ b/src/Kelpie.jl
@@ -126,13 +126,14 @@ function html_element(name::AbstractString, content...=nothing; kwargs...)
 end #function
 
 """
-    html(content...)
+    html(content...=nothing; kwargs...)
 
 Creates a new HTML document filled with `content`.
 """
-function html(content...)
+function html(content...=nothing; kwargs...)
     doc = EzXML.HTMLDocumentNode("about:legacy-compat", nothing)
-    link_or_text!(doc, content...)
+    node = html_element("html", content...; kwargs...)
+    link!(doc, node)
     return doc
 end #function
 


### PR DESCRIPTION
Fixes the `html` function to return an `<html>` node, not just an HTML document.